### PR TITLE
Add Redis cache to movie_poster_svc

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -187,6 +187,14 @@ module applicationInsights 'modules/app-insights.bicep' = {
   ]
 }
 
+module redis 'modules/redis.bicep' = {
+  name: 'redis-cache'
+  params: {
+    location: location
+    redisCacheName: 'azure-rambi-redis-${uniqueString(resourceGroup().id)}'
+  }
+}
+
 @description('Creates an Azure Container Registry.')
 resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-01-01-preview' = {
   name: acrName
@@ -301,6 +309,18 @@ resource containerMoviePosterSvcApp 'Microsoft.App/containerApps@2024-10-02-prev
           name: 'apim-endpoint'
           value: apiManagement.outputs.apiManagementProxyHostName
         }
+        {
+          name: 'redis-host'
+          value: redis.outputs.redisHost
+        }
+        {
+          name: 'redis-port'
+          value: redis.outputs.redisPort
+        }
+        {
+          name: 'redis-password'
+          value: redis.outputs.redisPassword
+        }
       ]
       registries: [
         {
@@ -354,6 +374,18 @@ resource containerMoviePosterSvcApp 'Microsoft.App/containerApps@2024-10-02-prev
             {
               name: 'OTEL_RESOURCE_ATTRIBUTES'
               value: 'service.namespace=azure-rambi,service.instance.id=movie-poster-svc'
+            }
+            {
+              name: 'REDIS_HOST'
+              secretRef: 'redis-host'
+            }
+            {
+              name: 'REDIS_PORT'
+              secretRef: 'redis-port'
+            }
+            {
+              name: 'REDIS_PASSWORD'
+              secretRef: 'redis-password'
             }
           ]
           probes: [

--- a/infra/modules/redis.bicep
+++ b/infra/modules/redis.bicep
@@ -1,0 +1,22 @@
+@description('Location of the resources')
+param location string = resourceGroup().location
+
+@description('The name of the Redis Cache instance')
+param redisCacheName string
+
+resource redisCache 'Microsoft.Cache/redis@2020-06-01' = {
+  name: redisCacheName
+  location: location
+  sku: {
+    name: 'Standard'
+    family: 'C'
+    capacity: 1
+  }
+  properties: {
+    enableNonSslPort: false
+  }
+}
+
+output redisHost string = redisCache.properties.hostName
+output redisPort int = 6379
+output redisPassword string = listKeys(redisCache.id, '2020-06-01').primaryKey


### PR DESCRIPTION
Implement a caching mechanism for the `movie_poster_describe` function using Redis.

* **src/movie_poster_svc/main.py**
  - Import the `redis` library.
  - Initialize Redis client in the `GenAiMovieService` class constructor.
  - Modify `describe_poster` method to check Redis cache before making API call.
  - Store the result of the `describe_poster` method in Redis cache.

* **infra/main.bicep**
  - Add a new module to create an Azure Redis Cache instance.
  - Update environment variables to include Redis host, port, and password.

* **infra/modules/redis.bicep**
  - Define a new Bicep module to create an Azure Redis Cache instance.
  - Output Redis host, port, and password.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bmoussaud/azure-rambi/pull/1?shareId=11d4654e-beac-4684-8df1-92a50169d2c3).